### PR TITLE
Translate and expand code comments

### DIFF
--- a/piccolo_teatro/__init__.py
+++ b/piccolo_teatro/__init__.py
@@ -1,3 +1,5 @@
 from piccolo_teatro.config import TimeSeriesEngine
 
+# Provide a shared TimeSeriesEngine instance configured with the default
+# feature set so that other modules can import and reuse it directly.
 ts_engine = TimeSeriesEngine()

--- a/piccolo_teatro/config/__init__.py
+++ b/piccolo_teatro/config/__init__.py
@@ -5,18 +5,24 @@ from skopt.space import Real, Integer
 
 class XGBConfig(BaseModel):
 
+    # Hyperparameter search space explored during Bayesian optimization for
+    # the XGBoost regressor.
     param_space: dict = {
         'n_estimators': Integer(100, 300),
         'max_depth': Integer(3, 10),
         'learning_rate': Real(0.01, 0.3, prior='log-uniform'),
         'subsample': Real(0.5, 1.0),
         'colsample_bytree': Real(0.5, 1.0)
-    }    
+    }
 
+    # Minimum Information Coefficient threshold used when evaluating
+    # predictions.
     ic_dim: confloat(ge=0.0, le=1.0) = 0.9
 
 
 class Feature(BaseModel):
+    # Metadata describing a single engineered feature or a group of related
+    # feature columns.
     columns: List[str]
     const: bool
     enabled: bool
@@ -34,6 +40,8 @@ class ProblemConfig(BaseModel):
 problem_config = ProblemConfig(target = "percentage_bought_log1p")
 class TimeSeriesEngine:
     def __init__(self, df=None):
+        # Store the dataset and propagate configuration defaults so that the
+        # engine knows which features and target to manage.
         self.df = df
         self.new_prediction = None
         self.periods = problem_config.periods
@@ -82,9 +90,10 @@ class TimeSeriesEngine:
                                                             const=True,
                                                             enabled=True,
                                                             update=self.__update_const)
-        
 
-        # Variables features
+
+        # Variable features that evolve over time as new predictions are
+        # generated.
         self.start_sales_distance: Feature = Feature(columns=["start_sales_distance"],
                                                             const=False,
                                                             enabled=True,
@@ -120,8 +129,9 @@ class TimeSeriesEngine:
                                                 const=False,
                                                 enabled=True,
                                                 update=self.__update_target)
-        
-        # Calling functions that generate multiple features (es. moving avg of multiple periods)
+
+        # Calling helper functions that generate families of time-based
+        # features (e.g., moving averages across multiple periods).
         self.__init_target_avg(enabled=True)
 
         self.__init_target_delta(enabled=True)
@@ -133,6 +143,8 @@ class TimeSeriesEngine:
     def update_features(self, prediction):
         if self.df is None:
             raise Exception("Please add a input df to Feature class before calling update_features")
+        # Store the predicted target value and reset the container for the
+        # synthetic row that will be appended to the dataset.
         self.new_prediction = prediction
         self.new_row = {}
 
@@ -144,6 +156,8 @@ class TimeSeriesEngine:
             update_function = feature.update
             update_function(feature.columns[0])
 
+        # Append the constructed feature row so future predictions can build
+        # on the extended history.
         self.new_row = pd.DataFrame(self.new_row)
         self.df = pd.concat([self.df, self.new_row], ignore_index=True)
 
@@ -200,11 +214,11 @@ class TimeSeriesEngine:
         self.new_row[f"{self.target}"] = [self.new_prediction]
 
     def __update_target_avg(self):
-        # concateno storico + nuova predizione
+        # Concatenate the historical target values with the latest prediction.
         values = self.df[f"{self.target}"].tolist() + [self.new_prediction]
         s = pd.Series(values)
         for period in self.periods:
-            # rolling mean e prendo solo l'ultimo
+            # Compute the rolling mean and keep only the latest value.
             avg_val = s.rolling(period).mean().iloc[-1]
             self.new_row[f"{self.target}_avg_{period}"] = avg_val
 
@@ -212,7 +226,7 @@ class TimeSeriesEngine:
         values = self.df[f"{self.target}"].tolist() + [self.new_prediction]
         s = pd.Series(values)
         for period in self.periods:
-            # differenza tra t e t-period
+            # Difference between the current value and the value at t - period.
             delta_val = s.diff(periods=period).iloc[-1]
             self.new_row[f"{self.target}_delta_{period}"] = delta_val
 
@@ -221,7 +235,7 @@ class TimeSeriesEngine:
         s = pd.Series(values)
         first_val = s.iloc[0]
         for period in self.periods:
-            # shift e fill dei NaN con il primo valore
+            # Shift the series and fill missing values with the initial value.
             shifted_val = s.shift(period).fillna(first_val).iloc[-1]
             self.new_row[f"{self.target}_shifted_{period}"] = shifted_val
 

--- a/piccolo_teatro/create_tex.py
+++ b/piccolo_teatro/create_tex.py
@@ -1,7 +1,8 @@
 import pandas as pd
 import re
 
-# Load the CSV
+# Utility script that converts a wide CSV file into multiple LaTeX tables that
+# each display eight columns at a time.
 df = pd.read_csv('/home/carlo/Data/dati_piccolo_teatro2/xgb_log_ic_1/train_validation_summary.csv')
 df.rename(columns=lambda col: re.sub(r'IntervalScore_(\w+)', r'IS_\1', col), inplace=True)
 # Split columns into chunks of 8, padding the last if necessary

--- a/piccolo_teatro/data_pipeline/__init__.py
+++ b/piccolo_teatro/data_pipeline/__init__.py
@@ -1,7 +1,9 @@
 from .ingestion import Sales, Products, Seasons
 from .transformation import add_features
 
+
 def clean_data(SALES, PRODUCTS, SEASONS):
+    # Wrap the raw tables in typed helpers and trigger their cleaning logic.
     sales = Sales(SALES)
     products = Products(PRODUCTS)
     seasons = Seasons(SEASONS)
@@ -11,17 +13,17 @@ def clean_data(SALES, PRODUCTS, SEASONS):
     seasons.clean()
     return sales, products, seasons
 
+
 def run_data_pipeline(SALES, PRODUCTS, SEASONS, show_id=None):
     """Ingesting and cleaning data"""
-    
+
     sales, products, seasons = clean_data(SALES, PRODUCTS, SEASONS)
     if show_id is not None:
         sales.get_same_show(show_id)
-    
+
     df = add_features(seasons=seasons,
                     products=products,
                     df=sales.df,
                     live_data=True)
-    
-    
+
     return df

--- a/piccolo_teatro/data_pipeline/create_model_dataset.py
+++ b/piccolo_teatro/data_pipeline/create_model_dataset.py
@@ -37,6 +37,8 @@ def save_splits(train: pd.DataFrame, validation: pd.DataFrame, test: pd.DataFram
 
 
 def create_full_datasets(sales: Sales, products: Products, seasons: Seasons, path: str, save_csv=False, train_dim=0.6, val_dim=0.2):
+    # Build per-show datasets and split them into train/validation/test
+    # directories so downstream training scripts can read them quickly.
     save_folder = f"{path}/shows/"
     if not os.path.isdir(save_folder):
         os.makedirs(save_folder)
@@ -51,14 +53,14 @@ def create_full_datasets(sales: Sales, products: Products, seasons: Seasons, pat
     val_shows = 0
     train_limit = total_shows*train_dim
     val_limit = total_shows*val_dim
-    groups = [(show, g) 
+    groups = [(show, g)
           for show, g in groups]
 
     np.random.seed(42)
     np.random.shuffle(groups)
     for i, (show_id, group) in enumerate(groups):
         print(f"{(i+1)/total_shows:.2%} processed")
-        
+
         group = add_features(seasons=seasons,
                              products=products,
                              df=group,
@@ -72,8 +74,9 @@ def create_full_datasets(sales: Sales, products: Products, seasons: Seasons, pat
             folder = "validation"
         else:
             folder = "test"
-        
-        # We save the data only if has at least 10 days of sales
+
+        # Only persist shows that contain at least 10 distinct days of sales
+        # data so that the models train on meaningful histories.
         if len(group.index.unique().tolist())>10:
             cols_with_missing = group.columns[group.isna().any()].tolist()
             rows_with_missing = group.index[group.isna().any(axis=1)].tolist()
@@ -83,6 +86,8 @@ def create_full_datasets(sales: Sales, products: Products, seasons: Seasons, pat
 
 
 # Loading data
+# Read the raw CSV exports and build clean Sales/Products/Seasons
+# containers used by the feature engineering pipeline.
 path = os.environ.get("FOLDER_PATH")
 SALES = pd.read_csv(path+"/D_SALES_LIST_SALES.csv", index_col=False)
 PRODUCTS = pd.read_csv(path+"/D_CONFIG_PROD_LIST.csv", index_col=False)
@@ -98,5 +103,6 @@ print(products.df.dtypes)
 print("Seasons Df:")
 print(f"Shape: {seasons.df.shape[0]} rows × {seasons.df.shape[1]} cols")
 print(seasons.df.dtypes)
+# Generate the parquet/CSV splits for downstream training.
 create_full_datasets(sales, products, seasons, path, save_csv=True)
 

--- a/piccolo_teatro/data_pipeline/ingestion.py
+++ b/piccolo_teatro/data_pipeline/ingestion.py
@@ -2,9 +2,11 @@ from pydantic import BaseModel
 from typing import List, Dict, Callable
 import pandas as pd
 
+
 class Sales():
     def __init__(self, initial_df):
-        # Dictionary mapping original column names to desired names
+        # Dictionary mapping original column names to standardized names used
+        # throughout the project.
         self.sales_cols = {
             "D_SALES_LIST_SALES_Individuali_Gruppi": "individuali_gruppi",
             "D_SALES_LIST_SALES_Tipologia_canale": "online_offline",
@@ -37,7 +39,7 @@ class Sales():
         self.rename_cols()
 
     def rename_cols(self):
-        # Some columns have a space before the name, we need to remove it:
+        # Some columns contain a leading space; strip it before renaming.
         self.df = self.df.rename(columns=lambda x: x.lstrip())
         self.df = self.df.rename(columns=self.sales_cols)
 
@@ -74,11 +76,11 @@ class Sales():
         self.df["date"] = pd.to_datetime(self.df["date"], errors='coerce')
 
     def clean_cols(self):
-        # keep only the coulmns needed
+        # Keep only the columns required for downstream processing.
         self.df = self.df[list(self.cols_too_keep)]
 
     def clean_rows(self):
-        
+
         self.df['season_id'] = self.df['season_id'].astype(int)
 
         # Exclude sales from specified seasons
@@ -88,11 +90,11 @@ class Sales():
         self.df = self.df[self.df['operation_kind'].isin(
             self.operations_to_keep)]
         
-        # considering only sales operations
+        # Consider only sale operations.
         self.df = self.df[self.df['operation_type'] == "Venduti"]
-    
+
     def assign_index(self):
-        self.df = self.df.set_index('date', drop=False) 
+        self.df = self.df.set_index('date', drop=False)
 
     def sort_values(self):
         self.df = self.df.sort_values('date')
@@ -108,6 +110,7 @@ class Sales():
         return self.df.groupby('show_id')
     
     def clean(self):
+        # Apply type casting, row filtering, and column pruning in sequence.
         self.assign_types()
         self.clean_rows()
         self.clean_cols()
@@ -115,6 +118,8 @@ class Sales():
 
 class Products():
     def __init__(self, initial_df):
+        # Rename raw product columns so the feature engineering pipeline can
+        # reference them consistently.
         self.products_cols = {
             "D_CONFIG_PROD_LIST_T_PRODUCT_ID": "show_id",
             "D_CONFIG_PROD_LIST_PERFORMANCE_STATE": "performance_state",
@@ -144,11 +149,13 @@ class Products():
             "max_tickets":int,})
         
     def clean(self):
+        # Apply the column renaming and type conversions on the product data.
         self.assign_types()
 
 class Seasons():
 
     def __init__(self, initial_df):
+        # Mapping for the season metadata columns.
         self.seasons_cols = {
             "season_id": "season_id",
             "season_name": "season_name",
@@ -178,4 +185,5 @@ class Seasons():
         self.df["fine_stagione"] = pd.to_datetime(self.df["fine_stagione"], errors='coerce')
         
     def clean(self):
+        # Convert season metadata columns to their appropriate dtypes.
         self.assign_types()

--- a/piccolo_teatro/data_pipeline/transformation.py
+++ b/piccolo_teatro/data_pipeline/transformation.py
@@ -15,6 +15,7 @@ path = os.environ.get("FOLDER_PATH")
 encoding_dict = ts_engine.encoding_dict
 
 def get_season_dates(seasons_df, season_id: str):
+    # Look up the sales window for the specified season.
     season_row = seasons_df[seasons_df["season_id"] == season_id]
     start_date = season_row["inizio_vendite"].iloc[0]
     end_date = season_row["fine_vendite"].iloc[0]
@@ -53,6 +54,8 @@ def add_show_info(products_df, df, show_id):
     year2 = "20" + preformance_season.split(' ')[1].split('/')[1]
     performances_same_show = performances_same_show.copy()
     
+    # Convert the textual representation of the performance day into a
+    # concrete datetime, handling Italian weekday abbreviations when present.
     if performances_same_show['performance_day'].iloc[0].split(" ")[0] in ["lun", "mar", "mer", "gio", "ven", "sab", "dom"]:
         performances_same_show.loc[:, 'performance_date'] = performances_same_show['performance_day'].apply(lambda x: get_day_month(x, year1, year2))
         performances_same_show.loc[:, "performance_date"] = pd.to_datetime(performances_same_show["performance_date"], format='%d/%m/%Y')
@@ -65,11 +68,14 @@ def add_show_info(products_df, df, show_id):
     # Get all the performances of the same show
     performances_same_show = products_df[products_df["show_id"]==show_id].copy()
 
+    # Ignore auxiliary performances and venues that are outside the modelling
+    # scope.
     performances_to_not_consider = [
         "Evento collaterale",
         "Altro",
         "Spettacolo per bambini e ragazzi",
     ]
+    # Restrict the venues to the main theatres considered in the analysis.
     spaces_to_consider = [
         "Teatro Studio Melato",
         "Teatro Strehler",
@@ -119,37 +125,39 @@ def add_features(seasons: Seasons, products: Products, df: pd.DataFrame, live_da
             else:
                 fill_date = df["last_date"].iloc[0]
 
-            # Aggiungo i dati dei giorni mancanti (giorni senza vendite), li riempio mettendo l'ultimo valore noto
+            # Insert any missing days (dates without sales) and forward-fill
+            # them using the most recent known values.
             date_range = pd.date_range(start=df["date"].min(), end=fill_date)
             df = df.set_index("date").reindex(date_range, method="ffill")
             df["date"] = df.index
 
-        
-            # Distanza della transazione dall'inizio e dalla fine della stagione
+
+            # Compute distances from the start/end of the season and overall
+            # sales progress.
             df["start_sales_distance"] = (df["date"]-start_date).dt.days.abs()
             df["end_season_distance"] = (df["date"]-end_date).dt.days.abs()
             df["sales_duration"] = (df["last_date"]-start_date).dt.days
             df["end_sales_distance"] = (df["last_date"]-df["date"]).dt.days
             df["percentage_sales_day"] = df["start_sales_distance"]/(df["last_date"]-start_date).dt.days
             df["percentage_sales_day"] = df["percentage_sales_day"]
-        
-        
-            # Numero biglietti rimanenti per raggiungere capienza massima
+
+
+            # Track remaining inventory and sales-derived percentages.
             df["remaining_tickets"] = df["show_capacity"]-df["tickets_cum_sum"]
             df["percentage_bought"] = df["tickets_cum_sum"]/df["show_capacity"]
             df["percentage_bought_delta"] = df["percentage_bought"].diff(periods=1)
 
-            
+
             df = add_log_transform(df, "percentage_bought")
 
             df = add_deltas(df, ["percentage_bought", "percentage_bought_log1p"], [2,4,6,8,10,15,20,30])
-            # Aggiungo medie mobili con differenti periodi
+            # Add moving averages for several rolling windows.
             df = add_moving_avarages(df, ["percentage_bought_delta", "gain_cum_sum", "tickets_cum_sum", "percentage_bought","percentage_bought_log1p"], [2,4,6,8,10,15,20,30])
 
-            # Aggiungo valori shiftati
+            # Add lagged versions of the selected features.
             df = add_shifted_values(df, ["percentage_bought_delta", "gain_cum_sum", "tickets_cum_sum", "percentage_bought","percentage_bought_log1p"], [2,4,6,8,10,15,20,30])
-            
-            # Aggiungo i possibili target da prevedere:
+
+            # Generate all potential target columns needed for training.
             df = add_targets(df, ["percentage_bought", "percentage_bought_log1p", "percentage_bought_delta"])
             
         else:

--- a/piccolo_teatro/data_pipeline/utils.py
+++ b/piccolo_teatro/data_pipeline/utils.py
@@ -3,6 +3,8 @@ import numpy as np
 from piccolo_teatro import ts_engine
 
 def one_hot_encode(df, encoding_dict):
+    # Expand categorical columns into one-hot encoded indicator columns based
+    # on the provided dictionary of possible values.
     for col_name in encoding_dict:
         values = encoding_dict[col_name]
         for value in values:
@@ -13,12 +15,16 @@ def one_hot_encode(df, encoding_dict):
 
 
 def add_log_transform(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    # Apply a log1p transform to stabilise growth trends and store it as a
+    # separate feature column.
     new_column = f"{column}_log1p"
     df[new_column] = np.log1p(df[column])
     return df
 
 
 def add_deltas(df, columns, lags):
+    # Create finite-difference features that measure change over each
+    # specified lag.
     df = df.copy()
     for col in columns:
         for lag in lags:
@@ -26,27 +32,34 @@ def add_deltas(df, columns, lags):
     return df
 
 def add_cumulative_sum(df, column_names: list[str]):
+    # Track cumulative totals for the provided columns.
     for col_name in column_names:
         df[col_name+"_cum_sum"] = df[col_name].cumsum()
     return df
 
 def add_moving_avarages(df, column_names: list[str], periods: list[int]):
+    # Compute moving averages for each column across every requested window.
     for period in periods:
         for col_name in column_names:
             df[col_name+f"_avg_{period}"] = df[col_name].rolling(period).mean()
     return df
 
 def add_shifted_values(df, column_names: list[str], periods: list[int]):
+    # Append lagged versions of each column so models can access prior values
+    # directly.
     for period in periods:
         for col_name in column_names:
             df[col_name+f"_shifted_{period}"] = df[col_name].shift(period).fillna(df[col_name].iloc[0])
     return df
 
 def print_unique_values(df):
+    # Helper routine to inspect the first few unique values of every column.
     for col_name in df.columns:
         print(f"{col_name}: {df[col_name].unique()[:10]}")
 
 def add_targets(df,columns):
+    # Shift each potential target column forward one step so the next day's
+    # value becomes the supervised learning target.
     df = df.copy()
     for col in columns:
         df.loc[:, f"TARGET_{col}"] = df[col].shift(-1)

--- a/piccolo_teatro/fix_ic.py
+++ b/piccolo_teatro/fix_ic.py
@@ -4,6 +4,8 @@ import numpy as np
 import glob
 import os
 
+# Rescale saved confidence intervals to adjust their width while preserving
+# the central prediction.
 folder = "/home/carlo/Data/dati_piccolo_teatro2/xgb_log_ic_1/train_validation"
 files = glob.glob(os.path.join(folder, "*.csv"))
 

--- a/piccolo_teatro/get_metrics.py
+++ b/piccolo_teatro/get_metrics.py
@@ -1,6 +1,8 @@
 
 from piccolo_teatro.train.metrics import TimeSeriesMetrics
 
+# Convenience script that loads saved predictions and prints evaluation
+# metrics for the requested dataset splits.
 folder = "/home/carlo/Data/dati_piccolo_teatro2/xgb_log_ic_1"
 for set_name in ["test", "train_validation"]:
     ts_metrics = TimeSeriesMetrics(folder+f"/{set_name}/", 0.5, 0.95)

--- a/piccolo_teatro/plotting.py
+++ b/piccolo_teatro/plotting.py
@@ -5,12 +5,14 @@ import pandas as pd
 import glob
 import os
 
+# Interactive helper to visualise random prediction intervals alongside the
+# true target curves for quick qualitative inspection.
 files = glob.glob(os.path.join("/home/carlo/Data/dati_piccolo_teatro2/xgb_log_ic_1/test", "*.csv"))
 metrics = pd.read_csv("/home/carlo/Data/dati_piccolo_teatro2/xgb_log/test_metrics.csv")
 while True:
     fig, axes = plt.subplots(3, 3, figsize=(12, 12))
     axes_flat = axes.flatten()
-    
+
     selected = 0
     plotted = []
     print(len(axes_flat))

--- a/piccolo_teatro/powerbi_visual/__init__.py
+++ b/piccolo_teatro/powerbi_visual/__init__.py
@@ -7,6 +7,8 @@ import matplotlib.pyplot as plt
 import matplotlib.style as style
 import plotly.graph_objects as go
 
+# Toolkit used by the Power BI integration to prepare show data, generate
+# forecasts, and visualise the resulting trends.
 ts_engine = TimeSeriesEngine()
 
 sales_cols = [
@@ -69,7 +71,8 @@ def rename_cols(dataset):
 
 def plot_trends(static, product_name, known_gain, known_trend, future_prediction, predicted_fixed_trend, scale_factor):
     if static:
-        
+
+        # Draw a static Matplotlib chart comparing known data and forecasts.
         plt.plot(future_prediction*scale_factor, color="orange", label="Future Prediction")
         plt.plot(known_trend*scale_factor, color="blue", label="Known Trend")
         if scale_factor != 1:
@@ -87,9 +90,10 @@ def plot_trends(static, product_name, known_gain, known_trend, future_prediction
         plt.show()
     else:
         fig = go.Figure()
+        # Build an interactive Plotly visual with the same layers.
         fig.add_trace(go.Scatter(x=future_prediction.index, y=future_prediction["predictions"]*scale_factor, mode='lines', name='Future Prediction', line=dict(width=4)))
         fig.add_trace(go.Scatter(x=known_trend.index, y=known_trend*scale_factor, mode='lines', name='Known Trend', line=dict(width=4)))
-        
+
         if scale_factor != 1:
             fig.add_trace(go.Scatter(x=future_prediction.index, y=known_gain, mode='lines', name='Future Prediction', line=dict(width=4)))
 
@@ -122,7 +126,7 @@ def powerbi_visual(dataset, offset, static = True, gain_trend = False):
 
     SALES, PRODUCTS, SEASONS = rename_cols(dataset)
 
-    # Get show info
+    # Extract show-level targets and metadata from the Power BI dataset.
     show_id = int(dataset["T_PRODUCT_ID"].iloc[0])
     target_perc = float(dataset["OBIETTIVO RIEMPIMENTO"].iloc[0])
     target_gain = float(dataset["OBIETTIVO INCASSO"].iloc[0])
@@ -131,7 +135,8 @@ def powerbi_visual(dataset, offset, static = True, gain_trend = False):
     product_name = dataset["PRODUCT_EXTERNAL_NAME"].iloc[-1]
 
     
-    # From raw data we run a pipelan that cleans them and adds features
+    # Run the preprocessing pipeline on the raw data to engineer the required
+    # features for forecasting.
     df = run_data_pipeline(SALES, PRODUCTS, SEASONS, show_id)
     sales_duration = df["sales_duration"].iloc[0]
     known_trend = df["percentage_bought"].copy()
@@ -143,13 +148,14 @@ def powerbi_visual(dataset, offset, static = True, gain_trend = False):
         scale_factor = capacity * (avg_ticket_price)
 
 
-    # Make prediction using all the known data
+    # Generate a full-trend prediction using all available observations.
     model = get_model("XGB_trend2")
     future_prediction = predict_trend(df, model)
     known_trend = known_trend.rename("predictions")
-    known_and_predicted = pd.concat([known_trend, future_prediction])    
+    known_and_predicted = pd.concat([known_trend, future_prediction])
 
-    # Generate fixed trend prediction if there is enoght data
+    # Optionally create a prediction that only uses the initial portion of the
+    # sales history to mimic an early forecast.
     predicted_fixed_trend = []
     if int(sales_duration * offset) <= len(df):
         fixed_df = df.head(int(sales_duration * offset)).copy()

--- a/piccolo_teatro/train/__init__.py
+++ b/piccolo_teatro/train/__init__.py
@@ -16,7 +16,8 @@ def separete_features_targets(df, sort=False, shuffle=False):
     if sort and shuffle:
         raise Exception("You can't both shuffle and sort, please choose one")
     
-    # Convert date column to datetime"
+    # Convert the 'date' column to datetime so temporal ordering can be
+    # enforced consistently.
     df.loc[:, "date"] = pd.to_datetime(df["date"], format='%d/%m/%Y')
     df = df.set_index("date")
 
@@ -36,7 +37,8 @@ def keep_enabled_columns(df):
     """
     Keeps only the enabled features and the target column
     """
-    # Removing not needed features
+    # Remove any feature groups that are currently disabled in the
+    # TimeSeriesEngine configuration.
     features = ts_engine.enabled_features
     target_col = f"TARGET_{ts_engine.target}"
     columns_to_keep = ["date", target_col]
@@ -47,6 +49,7 @@ def keep_enabled_columns(df):
     return df
 
 def abs_error(model, X, Y):
+        # Plot residuals and print the overall MAE to diagnose model fit.
         train_prediciton = model.predict(X)
         train_mae = mean_absolute_error(Y, train_prediciton)
         plt.plot(Y-X["percentage_bought"], "ro")

--- a/piccolo_teatro/train/bootstrap_ensemble.py
+++ b/piccolo_teatro/train/bootstrap_ensemble.py
@@ -25,12 +25,16 @@ from piccolo_teatro.train import keep_enabled_columns, separete_features_targets
 from piccolo_teatro.train.metrics import TimeSeriesMetrics
 from piccolo_teatro.trend_simulation import predict_trend
 
+# End-to-end training routine for fitting a bootstrap ensemble of XGBoost
+# models and evaluating their time-series forecasts.
 xgb_config = XGBConfig()
 load_dotenv(find_dotenv())
 path = os.getenv("FOLDER_PATH")
 
 
 def save_predicted_trends(index, target, mean, low, up, file_path):
+    # Persist the predicted intervals alongside the true values for a single
+    # show.
     df = pd.DataFrame({"lower": low, "upper": up, "mean": mean, "target": target})
     df.index = index
 
@@ -42,6 +46,7 @@ def save_predicted_trends(index, target, mean, low, up, file_path):
 
 
 def get_bootstrap_df(shows_df):
+    # Sample shows with replacement to build a bootstrap training dataset.
     sampled_dfs = random.choices(shows_df, k=len(shows_df))
     df_concat = pd.concat(sampled_dfs, ignore_index=True)
     return df_concat
@@ -63,7 +68,7 @@ def bootstrap_models(shows_df, best_params, n_bootstraps=100):
         train_X, train_Y = separete_features_targets(df, sort=False, shuffle=False)
         dtrain = xgb.DMatrix(train_X, label=train_Y)
 
-        # 3. Train model
+        # Train a booster on the sampled dataset.
         model = xgb.train(
             params=best_params,
             dtrain=dtrain,
@@ -76,6 +81,8 @@ def bootstrap_models(shows_df, best_params, n_bootstraps=100):
 
 
 def get_best_params(train_shows, n_splits):
+    # Aggregate all shows and run Bayesian optimisation with group-aware
+    # cross-validation to estimate robust hyperparameters.
     train_df = pd.concat(train_shows, axis=0, ignore_index=True)
     groups = train_df["show_id"].copy()
     train_df = keep_enabled_columns(train_df)
@@ -105,7 +112,8 @@ def get_best_params(train_shows, n_splits):
 
 
 def test_xgb(test_shows, models, lower_q, upper_q, folder, offset=0.4, plot=False):
-    # Getting already predicted and saved shows
+    # Identify shows that already have stored predictions to avoid recomputing
+    # them.
     saved_trends_folder = os.path.dirname(folder)
     already_saved = glob.glob(os.path.join(saved_trends_folder, "*.csv"))
     done_ids = []
@@ -119,21 +127,22 @@ def test_xgb(test_shows, models, lower_q, upper_q, folder, offset=0.4, plot=Fals
         i_show += 1
         show_id = show_df["show_id"].values[0]
 
-        # Skipping already predicted shows/too small
+        # Skip shows with existing predictions or very short histories.
         if str(show_id) in done_ids or int(len(show_df) * offset) < 30:
             print(show_id, "already_done or too small")
             continue
         print("Predicting shows:", i_show / n_show, i_show, n_show)
 
-        # Calculating target df which is the real trend line we want to predict
+        # Build the ground-truth trend we compare predictions against.
         target = show_df[["date", "percentage_bought"]].copy()
         target["date"] = pd.to_datetime(target["date"], format="%d/%m/%Y")
         target.set_index("date", inplace=True)
 
-        # getting only the first "offset" part of the dataset so we can predict the rest of the trend line
+        # Keep only the first "offset" portion of the series as the known
+        # context for forecasting the remaining days.
         known_df = show_df.head(int(len(show_df) * offset)).copy()
 
-        # Predicting the trend for each model in the ensemble
+        # Predict the remaining trajectory using every model in the ensemble.
         boot_preds = []
         for model in models:
             predicted_trend = predict_trend(
@@ -148,19 +157,20 @@ def test_xgb(test_shows, models, lower_q, upper_q, folder, offset=0.4, plot=Fals
         if ts_engine.quantile_regression is False:
 
             boot_preds = np.stack(boot_preds, axis=0)
-            # numero di bootstrap
+            # Number of bootstrap samples.
             B = boot_preds.shape[0]
 
-            # stima della media predetta
+            # Estimated mean prediction.
             mean = np.mean(boot_preds, axis=0)
-            # errore standard della media
+            # Standard error of the mean.
             se = np.std(boot_preds, axis=0, ddof=1)
-            # livello di confidenza (es. lower_q=0.025 e upper_q=0.975 → confidenza 95%)
+            # Desired confidence level (e.g., lower_q=0.025 and upper_q=0.975
+            # corresponds to 95%).
             alpha = 1 - (upper_q - lower_q)
             df = B - 1
-            # quantile t critico
+            # Critical t-quantile.
             t_crit = stats.t.ppf(1 - alpha / 2, df)
-            # calcolo dei limiti dell’intervallo di confidenza
+            # Compute the confidence interval bounds.
             lower = mean - t_crit * se
             upper = mean + t_crit * se
         else:
@@ -221,7 +231,7 @@ if __name__ == "__main__":
         save_ensemble(ts_engine.pb_name, ensemble)
 
 
-    # Creating a folder for storing predictions and metrics about the model
+    # Create the directory layout that will host predictions and metrics.
     save_folder = path + f"/{ts_engine.pb_name}/"
     if not os.path.isdir(save_folder):
         os.makedirs(save_folder)
@@ -235,7 +245,7 @@ if __name__ == "__main__":
         if set_name == "train_validation":
             shows = train_shows + validation_shows
 
-        # Getting predictions for test shows
+        # Generate predictions for all selected shows.
         test_xgb(
             shows,
             ensemble,
@@ -245,7 +255,7 @@ if __name__ == "__main__":
             plot=False,
         )
 
-        # Evaluating Metrics
+        # Evaluate and persist aggregated metrics for this dataset split.
         ts_metrics = TimeSeriesMetrics(save_folder + f"/{set_name}/", lower_q, upper_q)
         res = ts_metrics.evaluate([5, 10, 15, 20, 25, 30], save_folder, set_name)
         print(f"\nMetrics summart of {set_name} set:")

--- a/piccolo_teatro/trend_simulation/__init__.py
+++ b/piccolo_teatro/trend_simulation/__init__.py
@@ -3,7 +3,7 @@ from time import time
 import pandas as pd
 import matplotlib.pyplot as plt
 from ..train import keep_enabled_columns, separete_features_targets
-from ..config import TimeSeriesEngine 
+from ..config import TimeSeriesEngine
 import xgboost as xgb
 
 pd.set_option("display.max_columns", None)
@@ -24,27 +24,29 @@ def predict_trend(known_df, target, model, last_date):
     predictions = []
     predicitons_days = []
     
-    # Keep iterating until we predict the last day (day of the last performance of the show)
-    n_predictions = df["sales_duration"].iloc[0]-len(known_df)   
+    # Iterate until predictions reach the day before the final performance.
+    n_predictions = df["sales_duration"].iloc[0]-len(known_df)
 
     last_date = last_date-pd.Timedelta(days=1)
     while(current_day<last_date):
         current_day += pd.Timedelta(days=1)
-        
+
         input_row = ts_engine.df.iloc[[-1]]
         if isinstance(model, xgb.Booster):
             dmat = xgb.DMatrix(input_row)
             prediction = model.predict(dmat)[0]
         else:
             prediction = model.predict(input_row)[0]
-        
-        # Prediciton need to be always highes than the last percentage 
+
+        # Ensure the cumulative prediction never decreases relative to the
+        # latest known percentage.
         prediction = max(prediction, input_row.iloc[0][target])
 
         predictions.append(prediction)
         predicitons_days.append(current_day)
 
-        # Updating all the features with the new prediction
+        # Update the rolling feature set with the freshly predicted value so
+        # that the next iteration has an extended history.
         ts_engine.update_features(prediction)
 
     prediction_df = pd.DataFrame({"predictions": predictions}, index=predicitons_days)

--- a/piccolo_teatro/trend_simulation/historical_data.py
+++ b/piccolo_teatro/trend_simulation/historical_data.py
@@ -11,6 +11,7 @@ from . import predict_trend
 pd.set_option("display.max_columns", None)
 load_dotenv(find_dotenv())
 path = os.environ.get("FOLDER_PATH")
+# Load the pre-trained model used to simulate historical forecasts.
 model = pickle.load(open(r"C:\Users\39370\Desktop\piccolo_teatro\piccolo_teatro\models\XGB_trend2.pkl", "rb"))
 
 offset = 0.1
@@ -29,13 +30,14 @@ for show_id in ids:
     df = run_data_pipeline(SALES, PRODUCTS, SEASONS, show_id)
     print(df)
     print("len df", len(df))
-    # We are simulationg we don't know all the data
+    # Simulate limited visibility by only exposing the first portion of the
+    # sales history.
     unknown_trend = df["percentage_bought"].copy()
     known_df = df.head(int(len(df) * offset)).copy()
 
     predicted_trend = predict_trend(known_df, model)
 
-    # Plotting
+    # Plot the predicted versus actual cumulative sales trends.
     plt.plot(predicted_trend)
     plt.show()
     plt.plot(unknown_trend)


### PR DESCRIPTION
## Summary
- add concise English explanations to core modules such as the time-series engine, data pipeline, and training routines
- translate Italian comments to English across feature engineering and evaluation scripts
- document helper scripts to clarify their purpose for future maintainers

## Testing
- not run (comment-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cd618464188326a0f3873af02b5584